### PR TITLE
make contact details as links

### DIFF
--- a/src/component/Contact.js
+++ b/src/component/Contact.js
@@ -19,8 +19,8 @@ function Contact() {
               <h1 className="hire__text">Contact Me. </h1>{" "}
               {/* <p className='hire__text white'>I am looking for my first job:</p> */}
               <p className="hire__text white">
-                <strong>0526707895</strong> or email{" "}
-                <strong>orela231089@gmail.com</strong>
+                <a href="tel:+972526707895"><strong>052-6707895</strong></a> or email{" "}
+                <a href="mailto:orela231089@gmail.com"><strong>orela231089@gmail.com</strong></a>
               </p>
             </div>
             <div className="icons">


### PR DESCRIPTION
This change adds a few small properties:

1. The phone number and email are now clickable with `pointer: cursor`. I feel it should be like that, otherwise, it feels wrong.
2. I used a special `href` for email and phone, it will open the default Mail app or the dialer on click. [read more](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href)

You can use the preview link in the next comment from @netlify to see what it will look like.